### PR TITLE
BAU Ensure log group is created before the lambda

### DIFF
--- a/logs.tf
+++ b/logs.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_log_group" "lambda" {
-  name              = "/aws/lambda/${aws_lambda_function.this.function_name}"
+  name              = "/aws/lambda/${var.function_name}"
   retention_in_days = 30
 
   tags = {

--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,10 @@ resource "aws_lambda_function" "this" {
   tags = merge({
     Git_Repo = var.lambda_git_repo
   }, var.lambda_function_tags)
+
+  depends_on = [
+    aws_cloudwatch_log_group.lambda
+  ]
 }
 
 resource "aws_lambda_alias" "latest" {


### PR DESCRIPTION
The new repo doesn't have the change made in https://github.com/hmrc/infrastructure-pipeline-lambda-build/pull/86 so let's fix that!

